### PR TITLE
Fixing service port on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can then start the application like this:
 `DB_USERNAME=luke DB_PASSWORD=secret ./bin/www`
 
 
-Then go to http://localhost:3000
+Then go to http://localhost:8080
 
 
 #### Running on Openshift


### PR DESCRIPTION
While testing this starter with ODO, I found out that the default port that the app starts is **8080** and not **3000** that the doc says.