### PR TITLE
chore: change default dockerImage to ubi8/nodejs-16

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "pretest": "eslint --ignore-path .gitignore .",
     "test": "nyc --reporter=lcov mocha",
     "release": "standard-version -a",
-    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-14",
+    "openshift": "nodeshift --dockerImage=registry.access.redhat.com/ubi8/nodejs-16",
     "start": "node ."
   },
   "main": "./bin/www",


### PR DESCRIPTION
The application runs as expected locally and in the sandbox... but does not connect to the database. This is consistent between Node.js 14 and 16 so this is not a version issue.