### PR TITLE
OCPBUGS-39370: Update the default NodeJS version in the examples

### DIFF
--- a/.openshift/postgresql-template-persistent.json
+++ b/.openshift/postgresql-template-persistent.json
@@ -442,8 +442,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-      "value": "16-ubi8",
+      "description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+      "value": "18-ubi8",
       "required": true
     },
     {

--- a/.openshift/postgresql-template.json
+++ b/.openshift/postgresql-template.json
@@ -425,8 +425,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (14-ubi8, 16-ubi8, or latest).",
-      "value": "16-ubi8",
+      "description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
+      "value": "18-ubi8",
       "required": true
     },
     {


### PR DESCRIPTION
with a version that is available in the openshift/library.

This tries to fix https://issues.redhat.com/browse/OCPBUGS-39370