### PR TITLE
Update the default NodeJS version in template

### DIFF
--- a/.openshift/postgresql-template-persistent.json
+++ b/.openshift/postgresql-template-persistent.json
@@ -442,8 +442,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
-      "value": "18-ubi8",
+      "description": "Version of NodeJS image to be used (20-ubi8, or latest).",
+      "value": "20-ubi8",
       "required": true
     },
     {

--- a/.openshift/postgresql-template.json
+++ b/.openshift/postgresql-template.json
@@ -425,8 +425,8 @@
     {
       "name": "NODEJS_VERSION",
       "displayName": "Version of NodeJS Image",
-      "description": "Version of NodeJS image to be used (18-ubi8, 20-ubi8, or latest).",
-      "value": "18-ubi8",
+      "description": "Version of NodeJS image to be used (20-ubi8, or latest).",
+      "value": "20-ubi8",
       "required": true
     },
     {


### PR DESCRIPTION
As nodejs18 image is no longer present in the openshift/library